### PR TITLE
Mention keybinds in the appliaction and readme

### DIFF
--- a/Map Mapper 2.3/objects/obj_cursor/Draw_64.gml
+++ b/Map Mapper 2.3/objects/obj_cursor/Draw_64.gml
@@ -180,7 +180,7 @@ if (_button != 0) {
 		switch (_button) {
 		
 			case obj_gameController.color_button: {
-				draw_text(_left + 2, _top - 22, "COLOR MENU");
+				draw_text(_left + 2, _top - 45, "COLOR MENU\n(CTRL+C)");
 				break; }
 				
 			case obj_gameController.rgb_code_selection: {
@@ -196,30 +196,30 @@ if (_button != 0) {
 				break; }
 				
 			case obj_gameController.igmenu_button: {
-				draw_text(_left + 2, _top + 44, "MENU");
+				draw_text(_left + 2, _top + 44, "MENU (ESC)");
 				break; }
 				
 			#region menu buttons
 			case obj_gameController.pen_tool_button: {
-				draw_text(_left + 2, _top + 69, "PEN TOOL");
+				draw_text(_left + 2, _top + 69, "PEN TOOL (P)");
 				break; }
 			case obj_gameController.eyedropper_tool_button: {
 				draw_text(_left + 2, _top + 69, "color picker (ALT)"); 
 				break; }
 			case obj_gameController.color_brush_tool_button: {
-				draw_text(_left + 2, _top + 69, "color brush");
+				draw_text(_left + 2, _top + 69, "color brush (B)");
 				break; }
 			case obj_gameController.door_tool_button: {
-				draw_text(_left + 2, _top + 69, "connection tool");
+				draw_text(_left + 2, _top + 69, "connection tool (C)");
 				break; }
 			case obj_gameController.marker_tool_button: {
-				draw_text(_left + 2, _top + 69, "marker tool");
+				draw_text(_left + 2, _top + 69, "marker tool (M)");
 				break; }
 			case obj_gameController.selection_tool_button: {
-				draw_text(_left + 2, _top + 69, "selection tool");
+				draw_text(_left + 2, _top + 69, "selection tool (S)");
 				break; }
 			case obj_gameController.hammer_tool_button: {
-				draw_text(_left + 2, _top + 69, "hammer tool");
+				draw_text(_left + 2, _top + 69, "hammer tool (H)");
 				break; }
 			case obj_gameController.save_button: {
 				draw_text(_left + 2, _top + 69, "save map");

--- a/Readme.md
+++ b/Readme.md
@@ -10,26 +10,26 @@ While it was primarily designed for Metroid ROM-Hacks, you are able to use it fo
 
 You can switch between various tools by clicking the Menu icon on the top left.
 
-#### Pen Tool
+#### Pen Tool (P)
 The Pen Tool is used to add and remove map-tiles and also to add onto existing tiles. Left-click and drag to start a new Room. Right-click and drag to remove existing tiles. An existing room can be expanded by dragging off of an existing room.
 
-#### Color Picker
+#### Color Picker (ALT)
 The Color Picker allows you to Left-click on an already existing map-tile to copy the color of it as your primary color. You can quickly switch to it by pressing Alt.
 
-#### Color Brush
+#### Color Brush (B)
 With the Color Brush you can change the color of all map tiles of the selected tiles room. it is also possible to change all Map tiles with the same color to a new color. Left-click to change the color fo the selected room, right-click to change all tiles with the same color.
 
-#### Connection Tool
+#### Connection Tool (C)
 With the Connection Tool you can create connections between, or in, rooms. The connections have colors as well, just like tiles. They use the color you have currently selected, but you can quickly swap between four presets.  
 Drag over two tiles to create a connection between them. Dragging with Right-click deletes the connection. If you are unsure where you can create a connection, the cursor will show arrows pointing into possible locations.
 
-#### Marker Tool
+#### Marker Tool (M)
 The Marker Tool allows you to place a wide selection of markers on a Tile. Left-click to place your currently selected marker, Right-click to remove the placed marker.
 
-#### Hammer Tool
+#### Hammer Tool (H)
 The Hammer Tool allows you to change the shape of tiles, to either create Sloped-tiles or thinned-tiles. Left-click to change the shape of a tile, Left-click again to remove it. If you are unsure where you can change the shape, the cursor will show a hammer if it's possible to do so.
 
-#### Selection Tool
+#### Selection Tool (S)
 Currently broken
 
 You can Save and Load your current Rooms, by clicking on the save and load icons in the menu.


### PR DESCRIPTION
As the title says.
The keybinds for most tools are now being displayed in application as well as in the readme.
I refrained from displaying the keybinds for save and load, due to text clipping.
